### PR TITLE
Bugfix record 修复第一次提交代码的bug&修复录制时间超出expires后无法继续录制的bug

### DIFF
--- a/mainwindow/mainwindow.cpp
+++ b/mainwindow/mainwindow.cpp
@@ -5181,6 +5181,8 @@ void MainWindow::startRecordUrl(QString url)
     recordTimer->start();
     startRecordTime = QDateTime::currentMSecsSinceEpoch();
 
+    // 开始下载前 给m3u8Downloader挂载BiliLiveService
+    m3u8Downloader.SetLiveRoomService(liveService);
     // 开始下载
     m3u8Downloader.start(url, path);
 

--- a/third_party/m3u8_downloader/m3u8downloader.cpp
+++ b/third_party/m3u8_downloader/m3u8downloader.cpp
@@ -2,9 +2,11 @@
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QUrl>
+#include <QUrlQuery>
 #include <QDebug>
 #include <QFile>
 #include <QtMath>
+#include <QDateTime>
 #include "m3u8downloader.h"
 
 M3u8Downloader::M3u8Downloader(QObject *parent) : QObject(parent)
@@ -28,30 +30,55 @@ bool M3u8Downloader::isDownloading() const
     return ts_file != nullptr;
 }
 
+void M3u8Downloader::UpdateUrl()
+{
+    if(this->ptr_live_room_service != nullptr)
+    {
+        this->ptr_live_room_service->getRoomLiveVideoUrl([=](QString new_url){
+            this->m3u8_url = new_url;
+        });
+        QString url = this->m3u8_url;
+
+        if(!this->parseUrl(url))
+        {
+            return;
+        }
+    }
+}
+
+void M3u8Downloader::UpdateTsExpiresTimestamps(qint64 new_ts_record_expires_timestamps)
+{
+
+    this->ts_record_expires_timestamps = new_ts_record_expires_timestamps;
+}
+
+void M3u8Downloader::UpdateTsRecordTimestampsCurrent(qint64 new_ts_record_timestamps_current)
+{
+    if (new_ts_record_timestamps_current > this->ts_record_timestamps_current)
+    {
+        this->ts_record_timestamps_current = new_ts_record_timestamps_current;
+    }
+}
+
 void M3u8Downloader::start(QString url, QString file)
 {
+    this->ts_record_expires_timestamps = 0;
+    this->ts_record_timestamps_current = 0;
     qInfo() << "下载M3U8：" << url << "->" << file;
-    this->m3u8_url = url;
-    this->save_path = file;
 
-    int pos = url.indexOf("://");
-    pos += 3;
-    pos = url.lastIndexOf("/");
-    if (pos > 0)
+    this->save_path = file;
+    if(!this->parseUrl(url))
     {
-        this->domain_url = url.left(pos);
-    }
-    else
-    {
-        qWarning() << "无法获取域名：" << url;
         return;
     }
-
     startLoop();
 }
 
 void M3u8Downloader::stop()
 {
+    this->ts_record_expires_timestamps = 0;
+    this->ts_record_timestamps_current = 0;
+    this->ptr_live_room_service = nullptr;
     if (ts_file == nullptr)
         return ;
     ts_file->flush();
@@ -87,6 +114,11 @@ void M3u8Downloader::startLoop()
 
 void M3u8Downloader::getM3u8()
 {
+    // 预留一定时长，提前去更新url
+    if (this->ts_record_timestamps_current + this->duration >= this->ts_record_expires_timestamps)
+    {
+        UpdateUrl();
+    }
     QNetworkAccessManager manager;
     QNetworkRequest* request = new QNetworkRequest(QUrl(m3u8_url));
     QNetworkReply *reply = manager.get(*request);
@@ -95,14 +127,28 @@ void M3u8Downloader::getM3u8()
 
     if (!isDownloading())
         return ;
-
+    int http_status_code = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     QByteArray data = reply->readAll();
     // qDebug() << "meu8.file:" << data;
 
     delete reply;
     delete request;
-
-    parseM3u8(data);
+    // 这里的话 感觉应该用http的响应码来判断获取是否成功。2xx的视为成功
+    if (http_status_code >= 200 && http_status_code <300)
+    {
+        parseM3u8(data);
+    }
+    else
+    {
+        UpdateUrl();
+    }
+    /* 在parseM3u8里 启动了下一次下载数据的seq_timer
+     * 但是如果这一次获取data的时候，就失败了，那data就是空的，parseM3u8里当做数据正常去解析
+     * 这会导致next_seq prev_seq 数据是异常的
+     * 如果可以的话，能不能把seq_timer拿到这里
+     * 因为seq_timer启动的是nextSeq()方法，而nextSeq()也就是重复getM3u8
+    */
+    seq_timer.start();
 }
 
 void M3u8Downloader::parseM3u8(const QByteArray &data)
@@ -125,11 +171,30 @@ void M3u8Downloader::parseM3u8(const QByteArray &data)
 
     while (find_pos != -1)
     {
+        // 解析#EXT-X-PROGRAM-DATE-TIME:
+        s = "#EXT-X-PROGRAM-DATE-TIME:";
+        find_pos = data.indexOf(s, find_pos) + s.length();
+        line_pos = data.indexOf("\n", find_pos);
+        QString str_data_time = data.mid(find_pos, line_pos - find_pos);
+        QDateTime date_time = QDateTime::fromString(str_data_time, Qt::ISODate);
+
         s = "#EXTINF:";
         find_pos = data.indexOf(s, find_pos) + s.length();
         line_pos = data.indexOf("\n", find_pos);
         QString desc = data.mid(find_pos, line_pos - find_pos);
+        int comma_pos = desc.indexOf(",");
+        if (comma_pos != -1)
+        {
+            QString str_one_fragment_duration = desc.left(comma_pos);
 
+            double double_one_fragment_duration = str_one_fragment_duration.toDouble();
+            qint64 one_fragment_duration(double_one_fragment_duration);
+            if (date_time.isValid()) {
+                qint64 current_timestamps = date_time.toTime_t();
+                qint64 video_update_timestamps = current_timestamps + one_fragment_duration;
+                UpdateTsRecordTimestampsCurrent(video_update_timestamps);
+            }
+        }
         find_pos = line_pos + 1;
         line_pos = data.indexOf("\n", find_pos);
         QString ts_url = data.mid(find_pos, line_pos - find_pos);
@@ -137,6 +202,8 @@ void M3u8Downloader::parseM3u8(const QByteArray &data)
             ts_url = domain_url + (domain_url.endsWith("/") ? "" : "/") + ts_url;
 
         // 下一个
+        // 看了下m3u8的协议，下一个的开头应该得是#EXT-X-PROGRAM-DATE-TIME:
+        s = "#EXT-X-PROGRAM-DATE-TIME:";
         find_pos = data.indexOf(s, find_pos);
 
         // qDebug() << "    seq:" << next_seq << ", duration:" << duration << desc << ts_url;
@@ -145,7 +212,6 @@ void M3u8Downloader::parseM3u8(const QByteArray &data)
         downloadTs(next_seq - 1, ts_url);
     }
     prev_seq = next_seq - 1;
-    seq_timer.start();
 }
 
 void M3u8Downloader::downloadTs(int seq, QString url)
@@ -187,4 +253,42 @@ void M3u8Downloader::downloadTs(int seq, QString url)
 void M3u8Downloader::nextSeq()
 {
     getM3u8();
+}
+
+void M3u8Downloader::SetLiveRoomService(LiveRoomService* live_room_service)
+{
+    this->ptr_live_room_service = live_room_service;
+}
+
+bool M3u8Downloader::parseUrl(QString url)
+{
+    qInfo() << "下载M3U8：" << url;
+    this->m3u8_url = url;
+
+    int pos = url.indexOf("://");
+    pos += 3;
+    pos = url.lastIndexOf("/");
+    if (pos > 0)
+    {
+        this->domain_url = url.left(pos);
+    }
+    else
+    {
+        qWarning() << "无法获取域名：" << url;
+        return false;
+    }
+
+    QUrl qurl(url);
+
+    if (qurl.isValid())
+    {
+        QUrlQuery qurl_query(qurl);
+        if (qurl_query.hasQueryItem("expires"))
+        {
+            QString str_expires = qurl_query.queryItemValue("expires");
+            qint64 new_ts_expires_timestamps = str_expires.toLongLong();
+            UpdateTsExpiresTimestamps(new_ts_expires_timestamps);
+        }
+    }
+    return true;
 }

--- a/third_party/m3u8_downloader/m3u8downloader.cpp
+++ b/third_party/m3u8_downloader/m3u8downloader.cpp
@@ -36,7 +36,7 @@ void M3u8Downloader::start(QString url, QString file)
 
     int pos = url.indexOf("://");
     pos += 3;
-    pos = url.lastIndexOf("/", pos);
+    pos = url.lastIndexOf("/");
     if (pos > 0)
     {
         this->domain_url = url.left(pos);

--- a/third_party/m3u8_downloader/m3u8downloader.h
+++ b/third_party/m3u8_downloader/m3u8downloader.h
@@ -5,6 +5,7 @@
 #include <QEventLoop>
 #include <QTimer>
 #include <QFile>
+#include "liveroomservice.h"
 
 class M3u8Downloader : public QObject
 {
@@ -14,6 +15,8 @@ public:
     virtual ~M3u8Downloader();
 
     bool isDownloading() const;
+
+    void SetLiveRoomService(LiveRoomService* live_room_service);
 
 signals:
     void signalStarted();
@@ -31,6 +34,12 @@ private:
     void parseM3u8(const QByteArray& data);
     void downloadTs(int seq, QString url);
 
+    void UpdateUrl();
+    void UpdateTsExpiresTimestamps(qint64 new_ts_record_expires_timestamps);
+    void UpdateTsRecordTimestampsCurrent(qint64 new_ts_record_timestamps_current);
+
+    bool parseUrl(QString url);
+
 private slots:
     void nextSeq();
 
@@ -46,6 +55,13 @@ private:
     QList<QPair<int, QString>> ts_urls;
     qint64 start_timestamp = 0;
     qint64 total_size = 0;
+
+    // 记录当前ts录制时间戳，初始为0
+    qint64 ts_record_timestamps_current = 0;
+    // 录制参数里的expires
+    qint64 ts_record_expires_timestamps = 0;
+
+    LiveRoomService* ptr_live_room_service = nullptr;
 };
 
 #endif // M3U8DOWNLOADER_H


### PR DESCRIPTION
目前测试了一场3小时的录制。应该是没有问题了。
具体修复逻辑为，将LiveRoomService挂在M3u8Downloader中。当由于录制时间超出expires，需要更新录制url时，再次获取。
代码中没有增加一些分支判断，还有日志输出，这个可能就需要作者来补充了。