### PR TITLE
增加ChatGPT API地址输入框和添加Deepseek模型选项

### DIFF
--- a/global/usersettings.h
+++ b/global/usersettings.h
@@ -56,7 +56,7 @@ public:
     bool AIReplyMsgLocal = false;    // AI回复本地显示
     int AIReplyMsgSend = 0;          // AI回复发送弹幕，0关闭，1仅少量，2全部
 
-    QString chatgpt_endpiont;
+    QString chatgpt_endpiont = "https://api.deepseek.com/chat/completions";
     QString open_ai_key;
     QString chatgpt_model_name = "deepseek-chat";
     bool chatgpt_history_input = false;

--- a/global/usersettings.h
+++ b/global/usersettings.h
@@ -56,8 +56,9 @@ public:
     bool AIReplyMsgLocal = false;    // AI回复本地显示
     int AIReplyMsgSend = 0;          // AI回复发送弹幕，0关闭，1仅少量，2全部
 
+    QString chatgpt_endpiont;
     QString open_ai_key;
-    QString chatgpt_model_name = "gpt-3.5-turbo";
+    QString chatgpt_model_name = "deepseek-chat";
     bool chatgpt_history_input = false;
     int chatgpt_max_token_count = 2048;
     int chatgpt_max_context_count = 16;

--- a/mainwindow/mainwindow.cpp
+++ b/mainwindow/mainwindow.cpp
@@ -1667,6 +1667,7 @@ void MainWindow::readConfig()
 
     // chatgpt
     us->chatgpt_prompt = us->value("chatgpt/prompt").toString();
+    ui->chatGPTEndpointEdit->setText(us->chatgpt_endpiont = us->value("chatgpt/endpoint", us->chatgpt_endpiont).toString());
     ui->chatGPTKeyEdit->setText(us->open_ai_key = us->value("chatgpt/open_ai_key", us->open_ai_key).toString());
     ui->chatGPTModelNameCombo->setCurrentText(us->chatgpt_model_name = us->value("chatgpt/model_name", us->chatgpt_model_name).toString());
     ui->chatGPTMaxTokenCountSpin->setValue(us->chatgpt_max_token_count = us->value("chatgpt/max_token_count", us->chatgpt_max_token_count).toInt());
@@ -10577,6 +10578,11 @@ void MainWindow::on_closeGuiCheck_clicked()
             delete widget;
         }
     }
+}
+
+void MainWindow::on_chatGPTEndpointEdit_textEdited(const QString &arg1)
+{
+    us->setValue("chatgpt/endpoin", us->chatgpt_endpiont = arg1);
 }
 
 void MainWindow::on_chatGPTKeyEdit_textEdited(const QString &arg1)

--- a/mainwindow/mainwindow.h
+++ b/mainwindow/mainwindow.h
@@ -713,6 +713,8 @@ private slots:
 
     void on_emailFromEdit_editingFinished();
 
+    void on_chatGPTEndpointEdit_textEdited(const QString &arg1);
+
     void on_emailPasswordEdit_editingFinished();
 
 private:

--- a/mainwindow/mainwindow.ui
+++ b/mainwindow/mainwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1017</width>
-    <height>1854</height>
+    <height>1962</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -1845,8 +1845,8 @@ margin: 6px;</string>
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>925</width>
-             <height>1697</height>
+             <width>937</width>
+             <height>1846</height>
             </rect>
            </property>
            <property name="styleSheet">
@@ -2309,7 +2309,7 @@ margin: 40px;</string>
               <x>10</x>
               <y>1140</y>
               <width>171</width>
-              <height>231</height>
+              <height>301</height>
              </rect>
             </property>
             <property name="styleSheet">
@@ -2427,63 +2427,7 @@ QPushButton:pressed
              </item>
              <item>
               <layout class="QGridLayout" name="gridLayout_6">
-               <item row="2" column="0">
-                <widget class="QLabel" name="label_73">
-                 <property name="text">
-                  <string>token</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QComboBox" name="chatGPTModelNameCombo">
-                 <item>
-                  <property name="text">
-                   <string>gpt-3.5-turbo</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>gpt-3.5-turbo-16k</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>gpt-3.5-turbo-16k-0613</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>gpt-4</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>gpt-4-0613</string>
-                  </property>
-                 </item>
-                </widget>
-               </item>
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_71">
-                 <property name="toolTip">
-                  <string/>
-                 </property>
-                 <property name="text">
-                  <string>秘钥</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="label_72">
-                 <property name="toolTip">
-                  <string/>
-                 </property>
-                 <property name="text">
-                  <string>模型</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="1">
+               <item row="3" column="1">
                 <widget class="QSpinBox" name="chatGPTMaxTokenCountSpin">
                  <property name="contextMenuPolicy">
                   <enum>Qt::NoContextMenu</enum>
@@ -2524,7 +2468,68 @@ QPushButton:pressed
                  </property>
                 </widget>
                </item>
-               <item row="3" column="1">
+               <item row="1" column="1">
+                <widget class="QLineEdit" name="chatGPTKeyEdit">
+                 <property name="toolTip">
+                  <string>ChatGPT 秘钥
+支持OpenAI、API2D的秘钥</string>
+                 </property>
+                 <property name="styleSheet">
+                  <string notr="true">QLineEdit
+{
+	background: transparent;
+}</string>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QComboBox" name="chatGPTModelNameCombo">
+                 <item>
+                  <property name="text">
+                   <string>deepseek-chat</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>gpt-3.5-turbo</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>gpt-3.5-turbo-16k</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>gpt-3.5-turbo-16k-0613</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>gpt-4</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>gpt-4-0613</string>
+                  </property>
+                 </item>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="label_71">
+                 <property name="toolTip">
+                  <string/>
+                 </property>
+                 <property name="text">
+                  <string>秘钥</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
                 <widget class="QSpinBox" name="chatGPTMaxContextCountSpin">
                  <property name="contextMenuPolicy">
                   <enum>Qt::NoContextMenu</enum>
@@ -2565,7 +2570,14 @@ QPushButton:pressed
                  </property>
                 </widget>
                </item>
-               <item row="3" column="0">
+               <item row="0" column="0">
+                <widget class="QLabel" name="label_81">
+                 <property name="text">
+                  <string>API</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
                 <widget class="QLabel" name="label_75">
                  <property name="toolTip">
                   <string/>
@@ -2575,20 +2587,27 @@ QPushButton:pressed
                  </property>
                 </widget>
                </item>
-               <item row="0" column="1">
-                <widget class="QLineEdit" name="chatGPTKeyEdit">
-                 <property name="toolTip">
-                  <string>ChatGPT 秘钥
-支持OpenAI、API2D的秘钥</string>
+               <item row="3" column="0">
+                <widget class="QLabel" name="label_73">
+                 <property name="text">
+                  <string>token</string>
                  </property>
-                 <property name="styleSheet">
-                  <string notr="true">QLineEdit
-{
-	background: transparent;
-}</string>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="label_72">
+                 <property name="toolTip">
+                  <string/>
                  </property>
                  <property name="text">
-                  <string/>
+                  <string>模型</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLineEdit" name="chatGPTEndpointEdit">
+                 <property name="text">
+                  <string>https://api.deepseek.com/chat/completions</string>
                  </property>
                 </widget>
                </item>
@@ -2600,7 +2619,7 @@ QPushButton:pressed
             <property name="geometry">
              <rect>
               <x>10</x>
-              <y>1380</y>
+              <y>1460</y>
               <width>211</width>
               <height>301</height>
              </rect>

--- a/third_party/utils/chatgptutil.h
+++ b/third_party/utils/chatgptutil.h
@@ -98,6 +98,13 @@ public:
 
     void getResponse(const QJsonObject& paramJson)
     {
+        if (us->chatgpt_endpiont.isEmpty())
+        {
+            qWarning() << "未设置API地址";
+            emit signalResponseFinished();
+            return ;
+        }
+
         if (us->open_ai_key.isEmpty())
         {
             qWarning() << "未设置OpenAI秘钥";
@@ -105,15 +112,15 @@ public:
             return ;
         }
 
-        if (us->open_ai_key.startsWith("fk"))
-            url = "https://stream.api2d.net/v1/chat/completions";
-        else if (us->open_ai_key.startsWith("sk"))
-            url = "https://api.openai.com/v1/chat/completions";
-        else
-        {
-            url = "https://api.openai.com/v1/chat/completions";
-            qWarning() << "设置的不正确的key：" << us->open_ai_key;
-        }
+        url = us->chatgpt_endpiont;
+//        if (us->open_ai_key.startsWith("fk"))
+//            url = "https://stream.api2d.net/v1/chat/completions";
+//        else if (us->open_ai_key.startsWith("sk"))
+//            url = "https://api.openai.com/v1/chat/completions";
+//        else
+//        {
+//            // qWarning() << "设置的不正确的key：" << us->open_ai_key;
+//        }
 
         this->param_json = paramJson;
 


### PR DESCRIPTION
Deepseek跟OpenAI的API一样，可以直接使用，并且已将Deepseek的API地址以及模型设置为默认。

#27 
#47 