### PR TITLE
bugfix:修正解析DANMU_MSG消息时，解析字符串的json数据时，解析失败的bug

### DIFF
--- a/services/live_services/bilibili/bili_livecmds.cpp
+++ b/services/live_services/bilibili/bili_livecmds.cpp
@@ -879,7 +879,7 @@ void BiliLiveService::handleMessage(QJsonObject json)
                 "esports_jump_url": ""
             }
             */
-            MyJson extra = MyJson::from(extra_s.toLocal8Bit());
+            MyJson extra = MyJson::from(extra_s.toUtf8());
             if (!extra.isEmpty())
             {
                 bool show_reply = extra.b("show_reply");


### PR DESCRIPTION
修正解析DANMU_MSG消息时，解析字符串的json数据时，解析失败的bug